### PR TITLE
Use mapconcat in place of mapcar+concat

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,7 +1,6 @@
 * TODOs
 
 - Optimize unidecode-chars.el, probably the same way, as in Python Unidecode
-- In unidecode-unidecode function i can also use (map 'string ...) instead of (apply #'concat (mapcar ...)), but i'm not sure how to require cl-extra.el
 
 * How this package was made
 

--- a/unidecode.el
+++ b/unidecode.el
@@ -29,7 +29,7 @@
   code point of an original char")
 
 (defun unidecode-unidecode (s)
-  (apply #'concat (mapcar (lambda (ch) (elt unidecode-chars ch)) s)))
+  (mapconcat (lambda (ch) (elt unidecode-chars ch)) s ""))
 
 (defun unidecode-sanitize (s)
   "Strip all chars from string that are not alphanumeric or


### PR DESCRIPTION
Using `mapconcat` is a bit faster and produces less garbage without the need for `mapcar` to cons up the intermediate list.

It's not necessarily a huge improvement, but I thought it worth proposing since there was a related TODO item, which this change could supersede.